### PR TITLE
now named “unvanquished-mapeditor-support”

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-mapeditor-support
-=================
+unvanquished-mapeditor-support
+==============================
 
 Unvanquished support files for map editors.
 

--- a/build/gtkradiant/game/game.xlink
+++ b/build/gtkradiant/game/game.xlink
@@ -5,5 +5,5 @@
 	<item name="Unvanquished Wiki" url="https://wiki.unvanquished.net" />
 	<item name="Unvanquished Source" url="https://github.com/Unvanquished/Unvanquished" />
 	<item name="Unvanquished Bugtracker" url="https://github.com/Unvanquished/Unvanquished/issues" />
-	<item name="Unvanquished Gamepack Bugtracker" url="https://github.com/Unvanquished/mapeditor-support/issues" />
+	<item name="Unvanquished Gamepack Bugtracker" url="https://github.com/Unvanquished/unvanquished-mapeditor-support/issues" />
 </links>

--- a/build/gtkradiant/install/pkg/scripts/default_project.proj
+++ b/build/gtkradiant/install/pkg/scripts/default_project.proj
@@ -3,7 +3,7 @@
 
 <project>
 <key name="version" value="2" />
-<key name="template_version" value="6208" />
+<key name="template_version" value="6387" />
 <key name="basepath" value="$TEMPLATEenginepath$TEMPLATEbasedir/" />
 <key name="rshcmd" value="" />
 <key name="entitypath" value="$TEMPLATEtoolspath$TEMPLATEbasedir/scripts/entities.def" />

--- a/build/gtkradiant/install/pkg/scripts/entities.def
+++ b/build/gtkradiant/install/pkg/scripts/entities.def
@@ -14,11 +14,11 @@
 //
 // Bugs & Feedback:
 //   The issue tracker for this file can be found at GitHub:
-//     https://github.com/Unvanquished/mapeditor-support/issues
+//     https://github.com/Unvanquished/unvanquished-mapeditor-support/issues
 //
 //   If you don't have a GitHub account, you can try to contact the recent
 //   contributors via the Unvanquished forums:
-//     https://unvanquished.net/forum/
+//     https://forums.unvanquished.net
 //   or via the developers' IRC channel:
 //     irc.freenode.net, #unvanquished-dev
 

--- a/build/netradiant/README.md
+++ b/build/netradiant/README.md
@@ -4,6 +4,8 @@ Unvanquished support for Netradiant
 Installation
 ------------
 
+NetRadiant automatically fetches gamepacks it supports, you have no need to clone this repo.
+
 In the Netradiant preferences under *Settings/Paths*, point *Engine Path* to the folder that contains the game assets. After a map compilation, the gamepack will make the editor attempt to run `/usr/bin/unvanquished` instead of a binary inside this path.
 
 Using

--- a/build/netradiant/unvanquished.game/game.xlink
+++ b/build/netradiant/unvanquished.game/game.xlink
@@ -5,5 +5,5 @@
 	<item name="Unvanquished Wiki" url="https://wiki.unvanquished.net" />
 	<item name="Unvanquished Source" url="https://github.com/Unvanquished/Unvanquished" />
 	<item name="Unvanquished Bugtracker" url="https://github.com/Unvanquished/Unvanquished/issues" />
-	<item name="Unvanquished Gamepack Bugtracker" url="https://github.com/Unvanquished/mapeditor-support/issues" />
+	<item name="Unvanquished Gamepack Bugtracker" url="https://github.com/Unvanquished/unvanquished-mapeditor-support/issues" />
 </links>

--- a/build/netradiant/unvanquished.game/pkg/entities.def
+++ b/build/netradiant/unvanquished.game/pkg/entities.def
@@ -14,11 +14,11 @@
 //
 // Bugs & Feedback:
 //   The issue tracker for this file can be found at GitHub:
-//     https://github.com/Unvanquished/mapeditor-support/issues
+//     https://github.com/Unvanquished/unvanquished-mapeditor-support/issues
 //
 //   If you don't have a GitHub account, you can try to contact the recent
 //   contributors via the Unvanquished forums:
-//     https://unvanquished.net/forum/
+//     https://forums.unvanquished.net
 //   or via the developers' IRC channel:
 //     irc.freenode.net, #unvanquished-dev
 

--- a/docs/netradiant/README.md
+++ b/docs/netradiant/README.md
@@ -4,6 +4,8 @@ Unvanquished support for Netradiant
 Installation
 ------------
 
+NetRadiant automatically fetches gamepacks it supports, you have no need to clone this repo.
+
 In the Netradiant preferences under *Settings/Paths*, point *Engine Path* to the folder that contains the game assets. After a map compilation, the gamepack will make the editor attempt to run `/usr/bin/unvanquished` instead of a binary inside this path.
 
 Using

--- a/src/entities/header.txt
+++ b/src/entities/header.txt
@@ -14,10 +14,10 @@ Contributors:
 
 Bugs & Feedback:
   The issue tracker for this file can be found at GitHub:
-    https://github.com/Unvanquished/mapeditor-support/issues
+    https://github.com/Unvanquished/unvanquished-mapeditor-support/issues
 
   If you don't have a GitHub account, you can try to contact the recent
   contributors via the Unvanquished forums:
-    https://unvanquished.net/forum/
+    https://forums.unvanquished.net
   or via the developers' IRC channel:
     irc.freenode.net, #unvanquished-dev

--- a/src/xlink/game.xlink
+++ b/src/xlink/game.xlink
@@ -5,5 +5,5 @@
 	<item name="Unvanquished Wiki" url="https://wiki.unvanquished.net" />
 	<item name="Unvanquished Source" url="https://github.com/Unvanquished/Unvanquished" />
 	<item name="Unvanquished Bugtracker" url="https://github.com/Unvanquished/Unvanquished/issues" />
-	<item name="Unvanquished Gamepack Bugtracker" url="https://github.com/Unvanquished/mapeditor-support/issues" />
+	<item name="Unvanquished Gamepack Bugtracker" url="https://github.com/Unvanquished/unvanquished-mapeditor-support/issues" />
 </links>


### PR DESCRIPTION
@Viech I don't have permission to rename the repo myself. Can you both rename the repo and merge this PR in a row?

Right after this being done I will do a PR on netradiant's side to fetch this game pack (the renaming must be done first).

Merging this will fix #3 (already approved).