### PR TITLE
Almost follow XDG guidelines

### DIFF
--- a/build/gtkradiant/install/pkg/scripts/default_project.proj
+++ b/build/gtkradiant/install/pkg/scripts/default_project.proj
@@ -3,7 +3,7 @@
 
 <project>
 <key name="version" value="2" />
-<key name="template_version" value="6387" />
+<key name="template_version" value="6467" />
 <key name="basepath" value="$TEMPLATEenginepath$TEMPLATEbasedir/" />
 <key name="rshcmd" value="" />
 <key name="entitypath" value="$TEMPLATEtoolspath$TEMPLATEbasedir/scripts/entities.def" />

--- a/build/netradiant/games/unvanquished.game
+++ b/build/netradiant/games/unvanquished.game
@@ -9,7 +9,7 @@
   engine_win32="daemon.exe"
   engine_linux="../../../usr/bin/unvanquished"
   engine_macos="daemon.app"
-  prefix=".unvanquished"
+  prefix=".local/share/unvanquished"
   basegame="pkg"
   basegamename="Unvanquished"
   unknowngamename="Unvanquished Mod"

--- a/src/gamefile/file.game
+++ b/src/gamefile/file.game
@@ -9,7 +9,7 @@
   engine_win32="daemon.exe"
   engine_linux="../../../usr/bin/unvanquished"
   engine_macos="daemon.app"
-  prefix=".unvanquished"
+  prefix=".local/share/unvanquished"
   basegame="pkg"
   basegamename="Unvanquished"
   unknowngamename="Unvanquished Mod"


### PR DESCRIPTION
- move ~/.unvanquished to ~/.local/share/unvanquished

See Unvanquished/Unvanquished#730

GTK/NetRadiant do not handle XDG, so we hardcode `~/.local/share/…`. If someone altered `XDG_DATA_HOME`, he would probably know how to adjust GTK/NetRadiant too.