### PR TITLE
enable NetRadiant build menu's ExtraQ3map2Args option

### DIFF
--- a/build/gtkradiant/install/pkg/scripts/default_project.proj
+++ b/build/gtkradiant/install/pkg/scripts/default_project.proj
@@ -3,7 +3,7 @@
 
 <project>
 <key name="version" value="2" />
-<key name="template_version" value="6522" />
+<key name="template_version" value="6644" />
 <key name="basepath" value="$TEMPLATEenginepath$TEMPLATEbasedir/" />
 <key name="rshcmd" value="" />
 <key name="entitypath" value="$TEMPLATEtoolspath$TEMPLATEbasedir/scripts/entities.def" />

--- a/build/netradiant/unvanquished.game/default_build_menu.xml
+++ b/build/netradiant/unvanquished.game/default_build_menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <project version="2.0">
-<var name="q3map2">"[RadiantPath]q3map2.[ExecutableType]" -v<cond value="[MonitorAddress]"> -connect [MonitorAddress]</cond> -game unvanquished -fs_basepath "[EnginePath]" -fs_homepath "[UserEnginePath]" <cond value="[GameName]"> -fs_game [GameName]</cond></var>
+<var name="q3map2">"[RadiantPath]q3map2.[ExecutableType]" [ExtraQ3map2Args] -v<cond value="[MonitorAddress]"> -connect [MonitorAddress]</cond> -game unvanquished -fs_basepath "[EnginePath]" -fs_homepath "[UserEnginePath]" <cond value="[GameName]"> -fs_game [GameName]</cond></var>
 <build name="Build without visibility and lights">
 <command>[q3map2] -meta -custinfoparms "[MapFile]"</command>
 </build>

--- a/mkeditorpacks/tools/buildmenu.py
+++ b/mkeditorpacks/tools/buildmenu.py
@@ -121,7 +121,7 @@ def print_netradiant_file(data):
     project = ET.Element('project', attrib={'version': '2.0'})
 
     q3map2 = ET.SubElement(project, 'var', attrib={'name': 'q3map2'})
-    q3map2.text = '"[RadiantPath]q3map2.[ExecutableType]" -v'
+    q3map2.text = '"[RadiantPath]q3map2.[ExecutableType]" [ExtraQ3map2Args] -v'
     cond = ET.SubElement(q3map2, 'cond', attrib={'value': '[MonitorAddress]'})
     cond.text = ' -connect [MonitorAddress]'
     cond.tail = ' -game unvanquished -fs_basepath "[EnginePath]" -fs_homepath "[UserEnginePath]" '


### PR DESCRIPTION
It helps NetRadiant to add pakpath switches to q3map2 or switches to disables engine path and home path based on NetRadiant preferences.