### PR TITLE
entities: add `pos_navcon` entity

### DIFF
--- a/build/darkradiant/pkg/def/entities.def
+++ b/build/darkradiant/pkg/def/entities.def
@@ -1242,6 +1242,64 @@ entityDef info_player_start
 	"targetname" ""
 }
 
+entityDef pos_navcon_next
+{
+	// Class
+	"spawnclass" "iTarget"
+
+	// Description
+	"editor_usage" "Navmesh connection point (start point).\nLink it from a pos_navcon_start and the navmesh generator will generate a navmesh connection."
+
+	// Editor color
+	"editor_color" "ffcc44"
+
+	// Editor sizes
+	"editor_mins" "-8 -8 -8"
+	"editor_maxs" "8 8 8"
+
+	// Property description
+	"editor_var targetname" "[required] Name to use as target in a pos_navcon_start entity (or another pos_navcon_next in a chain). (string (targetname))"
+	"editor_var origin" "Position. (vec3_float)"
+	"editor_var target" "Set the name of another pos_navcon_next entity to connect them together in a chain. (string (target))"
+
+	// Property default value
+	"targetname" ""
+	"origin" ""
+	"target" ""
+}
+
+entityDef pos_navcon_start
+{
+	// Class
+	"spawnclass" "iTarget"
+
+	// Description
+	"editor_usage" "Navmesh connection point (next point).\nLink it to a pos_navcon_next and the navmesh generator will generate a navmesh connection."
+
+	// Editor color
+	"editor_color" "ffcc44"
+
+	// Editor sizes
+	"editor_mins" "-8 -8 -8"
+	"editor_maxs" "8 8 8"
+
+	// Property description
+	"editor_var target" "[required] Set the name of a pos_navcon_next entity to connect them together. (string (target))"
+	"editor_var origin" "Position. (vec3_float)"
+	"editor_var playerclasses" "Space-separated list of player classes that can go this route."
+	"editor_var playerteams" "Space-separated list of player teams that can go this route."
+	"editor_float size" "Radius. (float, def: 50)"
+	"editor_var spawnflags" "Spawn flags. (bitfield as an integer: BIDIR: 1)"
+
+	// Property default value
+	"target" ""
+	"origin" ""
+	"playerclasses" ""
+	"playerteams" ""
+	"size" "50"
+	"spawnflags" "0"
+}
+
 entityDef pos_target
 {
 	// Class

--- a/build/gtkradiant/install/pkg/scripts/default_project.proj
+++ b/build/gtkradiant/install/pkg/scripts/default_project.proj
@@ -3,7 +3,7 @@
 
 <project>
 <key name="version" value="2" />
-<key name="template_version" value="9039" />
+<key name="template_version" value="9041" />
 <key name="basepath" value="$TEMPLATEenginepath$TEMPLATEbasedir/" />
 <key name="rshcmd" value="" />
 <key name="entitypath" value="$TEMPLATEtoolspath$TEMPLATEbasedir/scripts/entities.def" />

--- a/build/gtkradiant/install/pkg/scripts/entities.def
+++ b/build/gtkradiant/install/pkg/scripts/entities.def
@@ -649,6 +649,30 @@ targetname: Can possibly be fired. (string (targetname))
 Use pos_player_intermission instead.
 */
 
+/*QUAKED pos_navcon_next (1 0.8 0.267) (-8 -8 -8) (8 8 8)
+------ PROPERTIES ------
+targetname: [required] Name to use as target in a pos_navcon_start entity (or another pos_navcon_next in a chain). (string (targetname))
+origin: Position. (vec3_float)
+target: Set the name of another pos_navcon_next entity to connect them together in a chain. (string (target))
+------ DESCRIPTION ------
+Navmesh connection point (start point).
+Link it from a pos_navcon_start and the navmesh generator will generate a navmesh connection.
+*/
+
+/*QUAKED pos_navcon_start (1 0.8 0.267) (-8 -8 -8) (8 8 8) BIDIR
+------ FLAGS ------
+BIDIR: Bidirectional.
+------ PROPERTIES ------
+target: [required] Set the name of a pos_navcon_next entity to connect them together. (string (target))
+origin: Position. (vec3_float)
+playerclasses: Space-separated list of player classes that can go this route.
+playerteams: Space-separated list of player teams that can go this route.
+size: Radius. (float, def: 50)
+------ DESCRIPTION ------
+Navmesh connection point (next point).
+Link it to a pos_navcon_next and the navmesh generator will generate a navmesh connection.
+*/
+
 /*QUAKED pos_target (0 0.498 0) (-8 -8 -8) (8 8 8)
 ------ PROPERTIES ------
 targetname: [required] Must be someone's target for aiming. (string (targetname))

--- a/build/jackhammer/install/unvanquished.fgd
+++ b/build/jackhammer/install/unvanquished.fgd
@@ -553,6 +553,26 @@
 	targetname(target_source) : Targetname :  : "Can possibly be fired."
 ]
 
+@PointClass size(-8 -8 -8, 8 8 8) color(255 204 68) = pos_navcon_next : "Navmesh connection point (start point).\n\nLink it from a pos_navcon_start and the navmesh generator will generate a navmesh connection."
+[
+	targetname(target_source) : Targetname :  : "[required] Name to use as target in a pos_navcon_start entity (or another pos_navcon_next in a chain)."
+	origin(string) : Origin :  : "Position."
+	target(target_destination) : Target :  : "Set the name of another pos_navcon_next entity to connect them together in a chain."
+]
+
+@PointClass size(-8 -8 -8, 8 8 8) color(255 204 68) = pos_navcon_start : "Navmesh connection point (next point).\n\nLink it to a pos_navcon_next and the navmesh generator will generate a navmesh connection."
+[
+	target(target_destination) : Target :  : "[required] Set the name of a pos_navcon_next entity to connect them together."
+	origin(string) : Origin :  : "Position."
+	playerclasses(string) : Playerclasses :  : "Space-separated list of player classes that can go this route."
+	playerteams(string) : Playerteams :  : "Space-separated list of player teams that can go this route."
+	size(string) : Size : 50 : "Radius."
+	spawnflags(flags) = 
+	[
+		1 : "Bidir" : : "Bidirectional."
+	]
+]
+
 @PointClass flags(Angle) size(-8 -8 -8, 8 8 8) color(0 127 0) = pos_target : "Aiming target for entities like light, gfx_portal_camera and env_afx_push.\n\nUsed as a positional target for entities that can use directional pointing."
 [
 	targetname(target_source) : Targetname :  : "[required] Must be someone's target for aiming."

--- a/build/netradiant/unvanquished.game/pkg/entities.ent
+++ b/build/netradiant/unvanquished.game/pkg/entities.ent
@@ -653,6 +653,30 @@ Use pos_player_intermission instead.
 <targetname key="targetname" name="targetname">Can possibly be fired. (string (targetname))</targetname>
 </point>
 
+<point name="pos_navcon_next" color="1 0.8 0.267" box="-8 -8 -8 8 8 8">
+------ DESCRIPTION ------
+Navmesh connection point (start point).
+Link it from a pos_navcon_start and the navmesh generator will generate a navmesh connection.
+------ PROPERTIES ------
+<targetname key="targetname" name="targetname">[required] Name to use as target in a pos_navcon_start entity (or another pos_navcon_next in a chain). (string (targetname))</targetname>
+<real3 key="origin" name="origin">Position. (vec3_float)</real3>
+<target key="target" name="target">Set the name of another pos_navcon_next entity to connect them together in a chain. (string (target))</target>
+</point>
+
+<point name="pos_navcon_start" color="1 0.8 0.267" box="-8 -8 -8 8 8 8">
+------ DESCRIPTION ------
+Navmesh connection point (next point).
+Link it to a pos_navcon_next and the navmesh generator will generate a navmesh connection.
+------ SPAWNFLAGS ------
+<flag key="BIDIR" name="BIDIR" bit="0">Bidirectional.</flag>
+------ PROPERTIES ------
+<target key="target" name="target">[required] Set the name of a pos_navcon_next entity to connect them together. (string (target))</target>
+<real3 key="origin" name="origin">Position. (vec3_float)</real3>
+<string key="playerclasses" name="playerclasses">Space-separated list of player classes that can go this route.</string>
+<string key="playerteams" name="playerteams">Space-separated list of player teams that can go this route.</string>
+<real key="size" name="size" value="50">Radius. (float, def: 50)</real>
+</point>
+
 <point name="pos_target" color="0 0.498 0" box="-8 -8 -8 8 8 8">
 ------ DESCRIPTION ------
 Aiming target for entities like light, gfx_portal_camera and env_afx_push.

--- a/build/trenchbroom/games/Unvanquished/entities.ent
+++ b/build/trenchbroom/games/Unvanquished/entities.ent
@@ -653,6 +653,30 @@ Use pos_player_intermission instead.
 <targetname key="targetname" name="targetname">Can possibly be fired. (string (targetname))</targetname>
 </point>
 
+<point name="pos_navcon_next" color="1 0.8 0.267" box="-8 -8 -8 8 8 8">
+------ DESCRIPTION ------
+Navmesh connection point (start point).
+Link it from a pos_navcon_start and the navmesh generator will generate a navmesh connection.
+------ PROPERTIES ------
+<targetname key="targetname" name="targetname">[required] Name to use as target in a pos_navcon_start entity (or another pos_navcon_next in a chain). (string (targetname))</targetname>
+<real3 key="origin" name="origin">Position. (vec3_float)</real3>
+<target key="target" name="target">Set the name of another pos_navcon_next entity to connect them together in a chain. (string (target))</target>
+</point>
+
+<point name="pos_navcon_start" color="1 0.8 0.267" box="-8 -8 -8 8 8 8">
+------ DESCRIPTION ------
+Navmesh connection point (next point).
+Link it to a pos_navcon_next and the navmesh generator will generate a navmesh connection.
+------ SPAWNFLAGS ------
+<flag key="BIDIR" name="BIDIR" bit="0">Bidirectional.</flag>
+------ PROPERTIES ------
+<target key="target" name="target">[required] Set the name of a pos_navcon_next entity to connect them together. (string (target))</target>
+<real3 key="origin" name="origin">Position. (vec3_float)</real3>
+<string key="playerclasses" name="playerclasses">Space-separated list of player classes that can go this route.</string>
+<string key="playerteams" name="playerteams">Space-separated list of player teams that can go this route.</string>
+<real key="size" name="size" value="50">Radius. (float, def: 50)</real>
+</point>
+
 <point name="pos_target" color="0 0.498 0" box="-8 -8 -8 8 8 8">
 ------ DESCRIPTION ------
 Aiming target for entities like light, gfx_portal_camera and env_afx_push.

--- a/src/entities/entities.deftypes.yaml
+++ b/src/entities/entities.deftypes.yaml
@@ -31,6 +31,7 @@ period: *time
 radius: vec3_float
 random: float
 replacement: string
+size: float
 shader: string (texture)
 sound1to2: *sound
 sound2to1: *sound

--- a/src/entities/entities.yaml
+++ b/src/entities/entities.yaml
@@ -852,6 +852,39 @@
   aliasof: pos_player_spawn
   deprecated: y
   d3Class: idPlayerStart
+- name: pos_navcon_next
+  extend: [point]
+  d3Class: iTarget
+  color: ffcc44
+  props:
+    target: >
+      Set the name of another pos_navcon_next entity to connect them together in a chain.
+    targetname: >
+      [required] Name to use as target in a pos_navcon_start entity (or another pos_navcon_next in a chain).
+  desc: >
+    Navmesh connection point (start point).
+
+    Link it from a pos_navcon_start and the navmesh generator will generate a navmesh connection.
+- name: pos_navcon_start
+  extend: [point]
+  d3Class: iTarget
+  color: ffcc44
+  flags:
+  - BIDIR: Bidirectional.
+  props:
+    target: >
+      [required] Set the name of a pos_navcon_next entity to connect them together.
+    size: Radius.
+    playerclasses: >
+      Space-separated list of player classes that can go this route.
+    playerteams: >
+      Space-separated list of player teams that can go this route.
+  propdefaults:
+    size: 50
+  desc: >
+    Navmesh connection point (next point).
+
+    Link it to a pos_navcon_next and the navmesh generator will generate a navmesh connection.
 - name: pos_target
   extend: [chain_target,point]
   d3Class: idTarget


### PR DESCRIPTION
Add `pos_navcon` entity. When linked with a `target` having the same name of another `pos_navcon`'s `targetname`, the game will know it can generate a navcon there.

The `bidir` flag can be toggled to make the link bidirectional (from the game point of view, nothing is displayed differently in editor).

The `playerclasses` expects a space-separated strings of player classes able to use the navcon, for example: `builder level0 level1`.

It is expected the game implements the reading of those and generate the related navcons. This is to be done by someone else in the [Unvanquished](https://github.com/Unvanquished/Unvanquished/) repository.

The current design allows to link multiple navcons in a chain, I suggest that all linked navcons inherit the `playerclasses` from both sides, and chained navcons inherit all the player classes from previous `pos_navcon`, but it is recommended to set the playerclass in the first one (the one having no `targetname` field).

![20240509-115914-000 netradiant-pos-navcon](https://github.com/Unvanquished/unvanquished-mapeditor-support/assets/2311649/05be3ffe-1d50-49d2-8eee-ef7104966ac5)
